### PR TITLE
fix_backfill_api

### DIFF
--- a/extended_api/model/models.py
+++ b/extended_api/model/models.py
@@ -68,10 +68,14 @@ class BackfillDAGRunRequestSchema(Schema):
     start_date = fields.DateTime(data_key="startDate", required=True)
     end_date = fields.DateTime(data_key="endDate", required=True)
     job_name = fields.String(data_key="jobName", required=True)
+
     pool = fields.String(data_key="pool", required=False)
     rerun_failed_tasks = fields.Boolean(data_key="rerunFailedTasks", required=False)
     ignore_dependencies = fields.Boolean(data_key="ignoreDependencies", required=False)
     username = fields.String(data_key="username", required=False, default="Extended API")
+    continue_on_failures = fields.Boolean(data_key="continueOnFailures", required=False)
+    dry_run = fields.Boolean(data_key="dryRun", required=False)
+    run_backwards = fields.Boolean(data_key="runBackwards", required=False)
 
     @post_load
     def gen_command_list(self, data, **kwargs) -> Tuple[List[str], str]:
@@ -87,9 +91,19 @@ class BackfillDAGRunRequestSchema(Schema):
             command_list += ['--pool', data['pool']]
 
         if data.get("rerun_failed_tasks"):
-            command_list.append('--ignore-first-depends-on-past')
+            command_list.append('--rerun-failed-tasks')
+
         if data.get("ignore_dependencies"):
             command_list.append('--ignore-dependencies')
+
+        if data.get("continue_on_failures"):
+            command_list += ['--continue-on-failures']
+
+        if data.get("dry_run"):
+            command_list += ['--dry-run']
+
+        if data.get("run_backwards"):
+            command_list.append('--run-backwards')
 
         return command_list, data['username']
 

--- a/extended_api/static/openapi.json
+++ b/extended_api/static/openapi.json
@@ -108,15 +108,8 @@
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "Command execution result.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/commandResult"
-                }
-              }
-            }
+          "202": {
+            "description": "Backfill operation started."
           },
           "405": {
             "description": "Invalid input"
@@ -201,16 +194,28 @@
           },
           "rerunFailedTasks": {
             "type": "boolean",
-            "description": "if set, the backfill will auto-rerun all the failed tasks for the backfill date range instead of throwing exceptions"
+            "description": "If set, the backfill will auto-rerun all the failed tasks for the backfill date range instead of throwing exceptions"
           },
           "ignoreDependencies": {
             "type": "boolean",
-            "description": "if set, the backfill will delete existing backfill-related DAG runs and start anew with fresh, running DAG runs"
+            "description": "Skip upstream tasks, run only the tasks matching the regexp. Only works in conjunction with task_regex"
           },
           "username": {
             "type": "string",
             "default": "Extended API",
             "description": "Username who call this API"
+          },
+          "continueOnFailures": {
+            "type": "boolean",
+            "description": "If set, the backfill will keep going even if some of the tasks failed"
+          },
+          "dryRun": {
+            "type": "boolean",
+            "description": "If set, perform a dry run for each task. Only renders Template Fields for each task, nothing else"
+          },
+          "runBackwards": {
+            "type": "boolean",
+            "description": "If set, the backfill will run tasks from the most recent day first. if there are tasks that depend_on_past this option will throw an exception"
           }
         }
       },


### PR DESCRIPTION
The 504 Gateway Timeout error you're seeing is due to the server not getting a timely response from the Airflow backfill command. This is because the backfill operation takes time and doesn't instantly return a response.

Instead of waiting for the backfill operation to complete, I think we can return a response immediately to the client and let the operation continue in the background.

https://github.com/caoergou/airflow-extended-api-plugin/issues/2